### PR TITLE
feat: extend topics and preload filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,20 +55,65 @@
       <h3 class="text-lg font-semibold mb-1 text-[#624B78]">Safety Planning</h3>
       <p class="text-sm text-[#45375a]">Step-by-step tools to help you plan ahead and protect yourself and your loved ones.</p>
     </a>
-    <a href="#legal-support" class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition p-5 text-center focus:outline-none focus:ring-2 focus:ring-[#AC95C1]">
+    <a href="#legal" class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition p-5 text-center focus:outline-none focus:ring-2 focus:ring-[#AC95C1]">
       <div class="text-4xl mb-2" aria-hidden="true">⚖️</div>
-      <h3 class="text-lg font-semibold mb-1 text-[#624B78]">Legal Support</h3>
+      <h3 class="text-lg font-semibold mb-1 text-[#624B78]">Legal</h3>
       <p class="text-sm text-[#45375a]">Know your rights, navigate the courts, and understand your legal protections.</p>
     </a>
-    <a href="#housing-utilities" class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition p-5 text-center focus:outline-none focus:ring-2 focus:ring-[#AC95C1]">
+    <a href="#housing" class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition p-5 text-center focus:outline-none focus:ring-2 focus:ring-[#AC95C1]">
       <div class="text-4xl mb-2" aria-hidden="true">🏠</div>
-      <h3 class="text-lg font-semibold mb-1 text-[#624B78]">Housing & Utilities</h3>
+      <h3 class="text-lg font-semibold mb-1 text-[#624B78]">Housing</h3>
       <p class="text-sm text-[#45375a]">Guides and templates to secure safe housing or waive utility deposits quickly.</p>
     </a>
-    <a href="#tech-privacy" class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition p-5 text-center focus:outline-none focus:ring-2 focus:ring-[#AC95C1]">
+    <a href="#technology-safety" class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition p-5 text-center focus:outline-none focus:ring-2 focus:ring-[#AC95C1]">
       <div class="text-4xl mb-2" aria-hidden="true">💻</div>
-      <h3 class="text-lg font-semibold mb-1 text-[#624B78]">Technology & Privacy</h3>
+      <h3 class="text-lg font-semibold mb-1 text-[#624B78]">Technology Safety</h3>
       <p class="text-sm text-[#45375a]">Tips to protect your privacy online and on your devices.</p>
+    </a>
+    <a href="#child-welfare" class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition p-5 text-center focus:outline-none focus:ring-2 focus:ring-[#AC95C1]">
+      <div class="text-4xl mb-2" aria-hidden="true">🧒</div>
+      <h3 class="text-lg font-semibold mb-1 text-[#624B78]">Child Welfare</h3>
+      <p class="text-sm text-[#45375a]">Information for protecting children and supporting families.</p>
+    </a>
+    <a href="#advocacy-skills" class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition p-5 text-center focus:outline-none focus:ring-2 focus:ring-[#AC95C1]">
+      <div class="text-4xl mb-2" aria-hidden="true">🗣️</div>
+      <h3 class="text-lg font-semibold mb-1 text-[#624B78]">Advocacy Skills</h3>
+      <p class="text-sm text-[#45375a]">Training and tips for effective advocacy work.</p>
+    </a>
+    <a href="#prevention" class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition p-5 text-center focus:outline-none focus:ring-2 focus:ring-[#AC95C1]">
+      <div class="text-4xl mb-2" aria-hidden="true">🚫</div>
+      <h3 class="text-lg font-semibold mb-1 text-[#624B78]">Prevention</h3>
+      <p class="text-sm text-[#45375a]">Programs and resources focused on prevention.</p>
+    </a>
+    <a href="#youth" class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition p-5 text-center focus:outline-none focus:ring-2 focus:ring-[#AC95C1]">
+      <div class="text-4xl mb-2" aria-hidden="true">🧑‍🎓</div>
+      <h3 class="text-lg font-semibold mb-1 text-[#624B78]">Youth</h3>
+      <p class="text-sm text-[#45375a]">Programming and resources for youth audiences.</p>
+    </a>
+    <a href="#data-reporting" class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition p-5 text-center focus:outline-none focus:ring-2 focus:ring-[#AC95C1]">
+      <div class="text-4xl mb-2" aria-hidden="true">📊</div>
+      <h3 class="text-lg font-semibold mb-1 text-[#624B78]">Data &amp; Reporting</h3>
+      <p class="text-sm text-[#45375a]">Guidance on data collection and reporting.</p>
+    </a>
+    <a href="#wellness-self-care" class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition p-5 text-center focus:outline-none focus:ring-2 focus:ring-[#AC95C1]">
+      <div class="text-4xl mb-2" aria-hidden="true">🧘</div>
+      <h3 class="text-lg font-semibold mb-1 text-[#624B78]">Wellness &amp; Self-Care</h3>
+      <p class="text-sm text-[#45375a]">Resources to support personal wellbeing and self-care.</p>
+    </a>
+    <a href="#finance-budgeting" class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition p-5 text-center focus:outline-none focus:ring-2 focus:ring-[#AC95C1]">
+      <div class="text-4xl mb-2" aria-hidden="true">💰</div>
+      <h3 class="text-lg font-semibold mb-1 text-[#624B78]">Finance &amp; Budgeting</h3>
+      <p class="text-sm text-[#45375a]">Budgeting help and fiscal compliance guidance.</p>
+    </a>
+    <a href="#bipp" class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition p-5 text-center focus:outline-none focus:ring-2 focus:ring-[#AC95C1]">
+      <div class="text-4xl mb-2" aria-hidden="true">🔄</div>
+      <h3 class="text-lg font-semibold mb-1 text-[#624B78]">BIPP</h3>
+      <p class="text-sm text-[#45375a]">Batterer Intervention &amp; Prevention Program resources.</p>
+    </a>
+    <a href="#elections-voting" class="group bg-white rounded-2xl shadow-lg hover:shadow-2xl transition p-5 text-center focus:outline-none focus:ring-2 focus:ring-[#AC95C1]">
+      <div class="text-4xl mb-2" aria-hidden="true">🗳️</div>
+      <h3 class="text-lg font-semibold mb-1 text-[#624B78]">Elections &amp; Voting</h3>
+      <p class="text-sm text-[#45375a]">Learn about civic engagement and voter education.</p>
     </a>
   </nav>
 
@@ -95,19 +140,64 @@
     <p class="text-[#45375a]">Find tips and printable tools to help create a personalized safety plan.</p>
   </section>
 
-  <section id="legal-support" class="max-w-5xl mx-auto px-4 mb-16">
-    <h2 class="font-baskerville text-2xl mb-4">Legal Support</h2>
+  <section id="legal" class="max-w-5xl mx-auto px-4 mb-16">
+    <h2 class="font-baskerville text-2xl mb-4">Legal</h2>
     <p class="text-[#45375a]">Explore resources about your rights and navigating the legal system.</p>
   </section>
 
-  <section id="housing-utilities" class="max-w-5xl mx-auto px-4 mb-16">
-    <h2 class="font-baskerville text-2xl mb-4">Housing &amp; Utilities</h2>
+  <section id="housing" class="max-w-5xl mx-auto px-4 mb-16">
+    <h2 class="font-baskerville text-2xl mb-4">Housing</h2>
     <p class="text-[#45375a]">Access guides to secure housing and manage utilities safely.</p>
   </section>
 
-  <section id="tech-privacy" class="max-w-5xl mx-auto px-4 mb-16">
-    <h2 class="font-baskerville text-2xl mb-4">Technology &amp; Privacy</h2>
+  <section id="technology-safety" class="max-w-5xl mx-auto px-4 mb-16">
+    <h2 class="font-baskerville text-2xl mb-4">Technology Safety</h2>
     <p class="text-[#45375a]">Learn ways to protect your privacy on devices and online services.</p>
+  </section>
+
+  <section id="child-welfare" class="max-w-5xl mx-auto px-4 mb-16">
+    <h2 class="font-baskerville text-2xl mb-4">Child Welfare</h2>
+    <p class="text-[#45375a]">Resources focused on child protection and advocacy.</p>
+  </section>
+
+  <section id="advocacy-skills" class="max-w-5xl mx-auto px-4 mb-16">
+    <h2 class="font-baskerville text-2xl mb-4">Advocacy Skills</h2>
+    <p class="text-[#45375a]">Training to strengthen advocacy, leadership and communication.</p>
+  </section>
+
+  <section id="prevention" class="max-w-5xl mx-auto px-4 mb-16">
+    <h2 class="font-baskerville text-2xl mb-4">Prevention</h2>
+    <p class="text-[#45375a]">Programs and resources focused on prevention.</p>
+  </section>
+
+  <section id="youth" class="max-w-5xl mx-auto px-4 mb-16">
+    <h2 class="font-baskerville text-2xl mb-4">Youth</h2>
+    <p class="text-[#45375a]">Information and programming for youth audiences.</p>
+  </section>
+
+  <section id="data-reporting" class="max-w-5xl mx-auto px-4 mb-16">
+    <h2 class="font-baskerville text-2xl mb-4">Data &amp; Reporting</h2>
+    <p class="text-[#45375a]">Guidance on data collection and reporting outcomes.</p>
+  </section>
+
+  <section id="wellness-self-care" class="max-w-5xl mx-auto px-4 mb-16">
+    <h2 class="font-baskerville text-2xl mb-4">Wellness &amp; Self-Care</h2>
+    <p class="text-[#45375a]">Tips to support wellness and self-care for staff and survivors.</p>
+  </section>
+
+  <section id="finance-budgeting" class="max-w-5xl mx-auto px-4 mb-16">
+    <h2 class="font-baskerville text-2xl mb-4">Finance &amp; Budgeting</h2>
+    <p class="text-[#45375a]">Tools to manage finances and ensure fiscal compliance.</p>
+  </section>
+
+  <section id="bipp" class="max-w-5xl mx-auto px-4 mb-16">
+    <h2 class="font-baskerville text-2xl mb-4">BIPP</h2>
+    <p class="text-[#45375a]">Batterer Intervention &amp; Prevention Program resources.</p>
+  </section>
+
+  <section id="elections-voting" class="max-w-5xl mx-auto px-4 mb-16">
+    <h2 class="font-baskerville text-2xl mb-4">Elections &amp; Voting</h2>
+    <p class="text-[#45375a]">Civic engagement, voter education and policy advocacy.</p>
   </section>
 
   <!-- ===== Modal ===== -->

--- a/js/app.js
+++ b/js/app.js
@@ -18,7 +18,46 @@ const modalOverlay   = document.getElementById('modal-overlay');
 const modalContent   = document.getElementById('modal-content');
 const modalClose     = document.getElementById('modal-close');
 
-let resources = [];
+let resources = []
+
+const predefinedAudiences = [
+  'Survivors',
+  'Advocates',
+  'Campus Advocates',
+  'Child Welfare Partners',
+  'Data Administrators',
+  'Executive Directors',
+  'Educators',
+  'Finance Professionals',
+  'General Public',
+  'Grants Professionals',
+  'IT & Operations Staff',
+  'Legislators',
+  'Outreach Teams',
+  'Policy Professionals',
+  'Prevention Educators',
+  'Program Managers',
+  'Prosecutors',
+  'System Partners',
+  'Youth',
+  'Youth Allies'
+]
+
+const predefinedTopics = [
+  'Safety Planning',
+  'Housing',
+  'Legal',
+  'Technology Safety',
+  'Child Welfare',
+  'Advocacy Skills',
+  'Prevention',
+  'Youth',
+  'Data & Reporting',
+  'Wellness & Self-Care',
+  'Finance & Budgeting',
+  'BIPP',
+  'Elections & Voting'
+]
 
 // Load resource data
 fetch('data/resources.json')
@@ -32,12 +71,12 @@ fetch('data/resources.json')
 
 // Populate audience and topic filters
 function populateFilters() {
-  const audSet = new Set();
-  const topSet = new Set();
+  const audSet = new Set(predefinedAudiences)
+  const topSet = new Set(predefinedTopics)
   resources.forEach(r => {
-    (r.audience || []).forEach(a => audSet.add(a));
-    (r.topics   || []).forEach(t => topSet.add(t));
-  });
+    ;(r.audience || []).forEach(a => audSet.add(a))
+    ;(r.topics || []).forEach(t => topSet.add(t))
+  })
   // Audience
   audSet.forEach(a => {
     const opt = document.createElement('option');


### PR DESCRIPTION
## Summary
- predefine all standardized audience and topic options in JS
- update populateFilters to include predefined categories
- rename existing topic cards and add new topic navigation cards
- create matching sections for each new topic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686d76b64014833282cc84e31eb73c0f