### PR TITLE
fix: remove unused renderTabs call

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,7 +191,7 @@
           tabTopic.addEventListener("click", () => switchTab("topic"))
           tabAud.addEventListener("click", () => switchTab("audience"))
           clearBtn.addEventListener("click", clearFilters)
-          renderTabs()
+          updateTabStyles()
           renderCards()
         }
 


### PR DESCRIPTION
## Summary
- replace obsolete `renderTabs` call in `init()` with `updateTabStyles`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686eb14a4a008332af8e033f59c6c63c