### PR TITLE
Fix tab styling toggling

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,9 +207,35 @@
         function updateTabStyles() {
           if (activeTab === "topic") {
             tabTopic.classList.add("bg-[#624B78]", "text-white")
+            tabTopic.classList.remove(
+              "bg-white",
+              "text-[#624B78]",
+              "border",
+              "border-[#624B78]",
+            )
+
+            tabAud.classList.add(
+              "bg-white",
+              "text-[#624B78]",
+              "border",
+              "border-[#624B78]",
+            )
             tabAud.classList.remove("bg-[#624B78]", "text-white")
           } else {
             tabAud.classList.add("bg-[#624B78]", "text-white")
+            tabAud.classList.remove(
+              "bg-white",
+              "text-[#624B78]",
+              "border",
+              "border-[#624B78]",
+            )
+
+            tabTopic.classList.add(
+              "bg-white",
+              "text-[#624B78]",
+              "border",
+              "border-[#624B78]",
+            )
             tabTopic.classList.remove("bg-[#624B78]", "text-white")
           }
         }


### PR DESCRIPTION
## Summary
- tweak `updateTabStyles()` so the active tab has a purple background with white text and no border
- inactive tab now switches to white background with purple text and purple border

## Testing
- `npx prettier --write index.html`

------
https://chatgpt.com/codex/tasks/task_b_686ec723f4788332bfac05fd8df45203